### PR TITLE
[Fluent] Restyled DatePicker Control

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Theme/Dark.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Theme/Dark.xaml
@@ -452,7 +452,12 @@
     <SolidColorBrush x:Key="DatePickerFocusedBorderBrush" Color="{StaticResource SystemAccentColorLight2}" />
     <SolidColorBrush x:Key="DatePickerBackgroundFocused" Color="{StaticResource ControlFillColorInputActive}" />
     <SolidColorBrush x:Key="DatePickerBackgroundPointerOver" Color="{StaticResource ControlFillColorSecondary}" />
-    <SolidColorBrush x:Key="DatePickerPopupBackground" Color="{StaticResource AcrylicBackgroundFillColorDefault}"/>
+    <SolidColorBrush x:Key="DatePickerPopupBackground" Color="{StaticResource SolidBackgroundFillColorBase}"/>
+    <SolidColorBrush x:Key="DatePickerCalendarButtonBackground" Color="{StaticResource SubtleFillColorTransparent}"/>
+    <SolidColorBrush x:Key="DatePickerCalendarButtonBackgroundPointerOver" Color="{StaticResource SubtleFillColorSecondary}"/>
+    <SolidColorBrush x:Key="DatePickerCalendarButtonBackgroundPressed" Color="{StaticResource SubtleFillColorTertiary}"/>
+
+
 
     <!--  DynamicScrollBar  -->
     <SolidColorBrush x:Key="ScrollBarButtonBackground" Color="{StaticResource SubtleFillColorTransparent}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Theme/HC.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Theme/HC.xaml
@@ -327,6 +327,9 @@
     <SolidColorBrush x:Key="DatePickerBackgroundFocused" Color="{StaticResource SystemColorHighlightTextColor}" />
     <SolidColorBrush x:Key="DatePickerBackgroundPointerOver" Color="{StaticResource SystemColorHighlightTextColor}" />
     <SolidColorBrush x:Key="DatePickerPopupBackground" Color="{StaticResource SystemColorWindowColor}"/>
+    <SolidColorBrush x:Key="DatePickerCalendarButtonBackground" Color="{StaticResource SystemColorWindowColor}"/>
+    <SolidColorBrush x:Key="DatePickerCalendarButtonBackgroundPointerOver" Color="{StaticResource SystemColorHighlightTextColor}"/>
+    <SolidColorBrush x:Key="DatePickerCalendarButtonBackgroundPressed" Color="{StaticResource SystemColorHighlightTextColor}"/>
 
     <!--  DynamicScrollBar  -->
     <SolidColorBrush x:Key="ScrollBarButtonBackground" Color="Transparent" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Theme/Light.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Theme/Light.xaml
@@ -449,7 +449,10 @@
     <SolidColorBrush x:Key="DatePickerFocusedBorderBrush" Color="{StaticResource SystemAccentColorDark1}" />
     <SolidColorBrush x:Key="DatePickerBackgroundFocused" Color="{StaticResource ControlFillColorInputActive}" />
     <SolidColorBrush x:Key="DatePickerBackgroundPointerOver" Color="{StaticResource ControlFillColorSecondary}" />
-    <SolidColorBrush x:Key="DatePickerPopupBackground" Color="{StaticResource AcrylicBackgroundFillColorDefault}"/>
+    <SolidColorBrush x:Key="DatePickerPopupBackground" Color="{StaticResource ControlFillColorInputActive}"/>
+    <SolidColorBrush x:Key="DatePickerCalendarButtonBackground" Color="{StaticResource SubtleFillColorTransparent}"/>
+    <SolidColorBrush x:Key="DatePickerCalendarButtonBackgroundPointerOver" Color="{StaticResource SubtleFillColorSecondary}"/>
+    <SolidColorBrush x:Key="DatePickerCalendarButtonBackgroundPressed" Color="{StaticResource SubtleFillColorTertiary}"/>
 
     <!--  DynamicScrollBar  -->
     <SolidColorBrush x:Key="ScrollBarButtonBackground" Color="{StaticResource SubtleFillColorTransparent}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/DatePicker.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/DatePicker.xaml
@@ -13,32 +13,40 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:sys="clr-namespace:System;assembly=mscorlib">
 
-    <Thickness x:Key="DatePickerBorderThemeThickness">1,1,1,0</Thickness>
-    <Thickness x:Key="DatePickerAccentBorderThemeThickness">0,0,0,1</Thickness>
-    <Thickness x:Key="DatePickerLeftIconMargin">10,8,0,0</Thickness>
-    <Thickness x:Key="DatePickerRightIconMargin">0,8,10,0</Thickness>
-    <Thickness x:Key="DatePickerCalendarButtonMargin">0,5,4,0</Thickness>
-    <Thickness x:Key="DatePickerCalendarButtonPadding">0,0,0,0</Thickness>
-    <sys:Double x:Key="DatePickerCalendarButtonHeight">24</sys:Double>
-    <sys:Double x:Key="DatePickerCalendarButtonIconSize">14</sys:Double>
-    <sys:String x:Key="CalendarGlyph">&#xE787;</sys:String>
+    <Thickness x:Key="DatePickerBorderThickness">1</Thickness>
+    <Thickness x:Key="DatePickerCalendarButtonMargin">0,4,4,4</Thickness>
+    <sys:Double x:Key="DatePickerCalendarButtonIconSize">12</sys:Double>
+    <sys:String x:Key="DatePickerCalendarGlyph">&#xE787;</sys:String>
+    <Thickness x:Key="DatePickerPadding">12,0,4,2</Thickness>
 
     <Style x:Key="DefaultDatePickerTextBoxStyle" TargetType="{x:Type DatePickerTextBox}">
         <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-        <Setter Property="VerticalContentAlignment" Value="Stretch" />
-        <Setter Property="BorderBrush" Value="Transparent" />
-        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="AutomationProperties.Name" Value="{Binding Path=(AutomationProperties.Name), Mode=OneWay, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type DatePicker}}}" />
-        <Setter Property="Foreground" Value="{DynamicResource DatePickerTextBoxForeground}" />
         <Setter Property="CaretBrush" Value="{DynamicResource DatePickerTextBoxCaretBrush}" />
-        <Setter Property="SnapsToDevicePixels" Value="True" />
         <Setter Property="OverridesDefaultStyle" Value="True" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type DatePickerTextBox}">
-                    <Grid>
+                    <Border x:Name="RootBorder"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        Padding="{TemplateBinding Padding}">
+                        <Border.Resources>
+                            <Style x:Key="DatePickerScrollViewerStyle" TargetType="ScrollViewer">
+                                <Setter Property="OverridesDefaultStyle" Value="True" />
+                                <Setter Property="Template">
+                                    <Setter.Value>
+                                        <ControlTemplate TargetType="ScrollViewer">
+                                            <ScrollContentPresenter />
+                                        </ControlTemplate>
+                                    </Setter.Value>
+                                </Setter>
+                            </Style>
+                        </Border.Resources>
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup Name="WatermarkStates">
                                 <VisualStateGroup.Transitions>
@@ -53,19 +61,20 @@
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
 
-                        <Border Margin="{TemplateBinding Margin}">
-                            <Decorator x:Name="PART_ContentHost" Margin="{TemplateBinding Padding}" />
-                        </Border>
-                        <Border Margin="{TemplateBinding Margin}">
-                            <!-- This is a placeholder for DatePickerTextBox -->
-                            <ContentControl 
+                        <Grid x:Name="RootGrid"
+                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                            <ContentControl
                                 x:Name="PART_Watermark"
                                 Opacity="0"
-                                Margin="{TemplateBinding Padding}"
                                 Focusable="False"
                                 IsHitTestVisible="False" />
-                        </Border>
-                    </Grid>
+                            <ScrollViewer x:Name="PART_ContentHost" 
+                                          Style="{StaticResource DatePickerScrollViewerStyle}"
+                                          Padding="0" 
+                                          HorizontalScrollBarVisibility="Hidden" />
+                        </Grid>
+                    </Border>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
@@ -76,115 +85,111 @@
     </Style>
 
     <Style x:Key="DefaultDatePickerStyle" TargetType="{x:Type DatePicker}">
+        <!-- WinUI Setters. Needed ?? Or parity with Aero2 -->
+        <Setter Property="VerticalAlignment" Value="Center" />
+
         <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
         <Setter Property="ContextMenu" Value="{DynamicResource DefaultControlContextMenu}" />
         <Setter Property="CalendarStyle" Value="{DynamicResource DatePickerCalendarStyle}" />
+        <Setter Property="IsTodayHighlighted" Value="True" />
+        <Setter Property="SelectedDateFormat" Value="Short" />
         <Setter Property="Foreground" Value="{DynamicResource DatePickerForeground}" />
         <Setter Property="Background" Value="{DynamicResource DatePickerBackground}" />
         <Setter Property="BorderBrush" Value="{DynamicResource ControlElevationBorderBrush}" />
-        <Setter Property="BorderThickness" Value="{StaticResource DatePickerBorderThemeThickness}" />
-        <Setter Property="HorizontalAlignment" Value="Stretch" />
-        <Setter Property="VerticalAlignment" Value="Center" />
+        <Setter Property="BorderThickness" Value="{StaticResource DatePickerBorderThickness}" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-        <Setter Property="VerticalContentAlignment" Value="Top" />
-        <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
-        <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
-        <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
+        <Setter Property="VerticalContentAlignment" Value="Stretch" />
+        <Setter Property="Padding" Value="{DynamicResource DatePickerPadding}" />
         <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
-        <Setter Property="SnapsToDevicePixels" Value="True" />
         <Setter Property="OverridesDefaultStyle" Value="True" />
         <Setter Property="KeyboardNavigation.TabNavigation" Value="Local" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type DatePicker}">
                     <Grid>
+                        <Grid.Resources>
+                            <Style x:Key="DeleteButtonStyle" TargetType="Button">
+                                <Setter Property="Background" Value="Transparent" />
+                                <Setter Property="BorderBrush" Value="Transparent" />
+                                <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+                                <Setter Property="Width" Value="{Binding ActualHeight, RelativeSource={RelativeSource Self}}" />
+                                <Setter Property="OverridesDefaultStyle" Value="True" />
+                                <Setter Property="Template">
+                                    <Setter.Value>
+                                        <ControlTemplate TargetType="Button">
+                                            <Border x:Name="ButtonLayoutBorder"
+                                                Margin="{DynamicResource DatePickerCalendarButtonMargin}"
+                                                BorderBrush="{TemplateBinding BorderBrush}"
+                                                BorderThickness="{TemplateBinding BorderThickness}"
+                                                Background="{TemplateBinding Background}"
+                                                CornerRadius="{TemplateBinding Border.CornerRadius}">
+                                                <ContentPresenter x:Name="GlyphElement"
+                                                              TextElement.Foreground="{TemplateBinding Foreground}"
+                                                              VerticalAlignment="Center"
+                                                              HorizontalAlignment="Center" />
+                                            </Border>
+                                            <ControlTemplate.Triggers>
+                                                <Trigger Property="IsMouseOver" Value="True">
+                                                    <Setter Property="Background" Value="{DynamicResource ButtonBackgroundPointerOver}" />
+                                                </Trigger>
+                                                <Trigger Property="IsPressed" Value="True">
+                                                    <Setter Property="Background" Value="{DynamicResource ButtonBackgroundPressed}" />
+                                                </Trigger>
+                                            </ControlTemplate.Triggers>
+                                        </ControlTemplate>
+                                    </Setter.Value>
+                                </Setter>
+                            </Style>
+                        </Grid.Resources>
                         <Grid.RowDefinitions>
                             <RowDefinition Height="*" />
                             <RowDefinition Height="Auto" />
                         </Grid.RowDefinitions>
-                        <Grid Grid.Row="0">
-                            <Border
-                                x:Name="ContentBorder"
-                                MinWidth="{TemplateBinding MinWidth}"
-                                MinHeight="{TemplateBinding MinHeight}"
-                                Padding="0"
-                                HorizontalAlignment="Stretch"
-                                VerticalAlignment="Stretch"
-                                Background="{TemplateBinding Background}"
-                                BorderBrush="{TemplateBinding BorderBrush}"
-                                BorderThickness="{TemplateBinding BorderThickness}"
-                                CornerRadius="{TemplateBinding Border.CornerRadius}">
-                                <Grid x:Name="PART_Root" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="*" />
-                                        <ColumnDefinition Width="Auto" />
-                                    </Grid.ColumnDefinitions>
-                                    <Grid Grid.Column="0">
-                                        <DatePickerTextBox
-                                            x:Name="PART_TextBox"
-                                            Margin="0"
-                                            Padding="{TemplateBinding Padding}"
-                                            HorizontalAlignment="Stretch"
-                                            VerticalAlignment="Stretch"
-                                            ContextMenu="{TemplateBinding ContextMenu}"
-                                            Focusable="{TemplateBinding Focusable}"
-                                            Foreground="{TemplateBinding Foreground}" />
-                                    </Grid>
-                                    <!--  Buttons and Icons have no padding from the main element to allow absolute positions if height is larger than the text entry zone  -->
-                                    <Button
-                                        x:Name="PART_Button"
-                                        Grid.Column="1"
-                                        Width="{StaticResource DatePickerCalendarButtonHeight}"
-                                        Height="{StaticResource DatePickerCalendarButtonHeight}"
-                                        Margin="{StaticResource DatePickerCalendarButtonMargin}"
-                                        Padding="{StaticResource DatePickerCalendarButtonPadding}"
-                                        HorizontalAlignment="Center"
-                                        VerticalAlignment="Top"
-                                        HorizontalContentAlignment="Center"
-                                        VerticalContentAlignment="Center"
-                                        Background="Transparent"
-                                        BorderBrush="Transparent"
-                                        AutomationProperties.Name="{Binding Path=(AutomationProperties.Name), Mode=OneWay, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type DatePicker}}}"
-                                        Cursor="Arrow"
-                                        Focusable="True"
-                                        IsTabStop="True" >
-                                        <!--  WPF overrides paddings for button  -->
 
-                                        <TextBlock
-                                            Margin="{StaticResource DatePickerCalendarButtonPadding}"
-                                            HorizontalAlignment="Center"
-                                            VerticalAlignment="Center"
-                                            FontFamily="{DynamicResource SymbolThemeFontFamily}"
-                                            FontSize="{StaticResource DatePickerCalendarButtonIconSize}"
-                                            Foreground="{TemplateBinding Foreground}"
-                                            Text="{StaticResource CalendarGlyph}" />
-                                    </Button>
-                                </Grid>
-                            </Border>
-                            <!--  The Accent Border is a separate element so that changes to the border thickness do not affect the position of the element  -->
-                            <Border
-                                x:Name="AccentBorder"
-                                HorizontalAlignment="Stretch"
-                                VerticalAlignment="Stretch"
-                                BorderThickness="{StaticResource DatePickerAccentBorderThemeThickness}"
-                                CornerRadius="{TemplateBinding Border.CornerRadius}" 
-                                BorderBrush="{DynamicResource ControlStrongStrokeColorDefaultBrush}"/>
-                        </Grid>
+                        <Border x:Name="BorderElement"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            Background="{TemplateBinding Background}"
+                            CornerRadius="{TemplateBinding Border.CornerRadius}"
+                            MinHeight="32">
+                            <Grid x:Name="PART_Root">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+
+                                <DatePickerTextBox x:Name="PART_TextBox" 
+                                               Padding="{TemplateBinding Padding}"
+                                               HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                               VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+
+                                <Button x:Name="PART_Button" 
+                                    Grid.Column="1"
+                                    VerticalAlignment="Stretch"
+                                    Style="{StaticResource DeleteButtonStyle}"
+                                    MinWidth="30">
+                                    <TextBlock FontFamily="{DynamicResource SymbolThemeFontFamily}"
+                                           FontSize="{DynamicResource DatePickerCalendarButtonIconSize}"
+                                           Text="{StaticResource DatePickerCalendarGlyph}"
+                                           HorizontalAlignment="Center"
+                                           VerticalAlignment="Center" />
+                                </Button>
+                            </Grid>
+                        </Border>
+
                         <Popup
                             x:Name="PART_Popup"
                             Grid.Row="1"
-                            HorizontalAlignment="Stretch"
                             VerticalAlignment="Top"
                             AllowsTransparency="True"
                             Placement="Bottom"
-                            PlacementTarget="{Binding ElementName=PART_TextBox}"
+                            PlacementTarget="{Binding ElementName=PART_Root}"
                             StaysOpen="False" />
+
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsKeyboardFocusWithin" Value="True">
-                            <Setter TargetName="AccentBorder" Property="BorderThickness" Value="0,0,0,2" />
-                            <Setter TargetName="AccentBorder" Property="BorderBrush" Value="{DynamicResource DatePickerFocusedBorderBrush}" />
-                            <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource DatePickerBackgroundFocused}" />
+                            <Setter TargetName="BorderElement" Property="Background" Value="{DynamicResource DatePickerBackgroundFocused}" />
                         </Trigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
@@ -192,15 +197,14 @@
                                 <Condition Property="IsMouseOver" Value="True" />
                                 <Condition Property="IsKeyboardFocusWithin" Value="False" />
                             </MultiTrigger.Conditions>
-                            <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource DatePickerBackgroundPointerOver}" />
+                            <Setter TargetName="BorderElement" Property="Background" Value="{DynamicResource DatePickerBackgroundPointerOver}" />
                         </MultiTrigger>
                         <Trigger Property="IsEnabled" Value="True">
                             <Setter Property="Cursor" Value="IBeam" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
-                            <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource ControlFillColorDisabledBrush}" />
-                            <Setter TargetName="ContentBorder" Property="BorderBrush" Value="{DynamicResource ControlStrokeColorDefaultBrush}" />
-                            <Setter TargetName="AccentBorder" Property="BorderBrush" Value="{DynamicResource ControlStrokeColorDefaultBrush}" />
+                            <Setter TargetName="BorderElement" Property="Background" Value="{DynamicResource ControlFillColorDisabledBrush}" />
+                            <Setter TargetName="BorderElement" Property="BorderBrush" Value="{DynamicResource ControlStrokeColorDefaultBrush}" />
                             <Setter Property="Foreground" Value="{DynamicResource TextFillColorDisabledBrush}" />
                         </Trigger>
                     </ControlTemplate.Triggers>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/DatePicker.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/DatePicker.xaml
@@ -82,6 +82,17 @@
 
     <Style x:Key="DatePickerCalendarStyle" BasedOn="{StaticResource DefaultCalendarStyle}" TargetType="{x:Type Calendar}">
         <Setter Property="Background" Value="{DynamicResource DatePickerPopupBackground}" />
+        <Setter Property="Border.CornerRadius" Value="{DynamicResource OverlayCornerRadius}" />
+        <Setter Property="Margin" Value="10"/>
+        <Setter Property="Effect">
+            <Setter.Value>
+                <DropShadowEffect
+                    BlurRadius="20"
+                    Direction="270"
+                    Opacity="0.25"
+                    ShadowDepth="6" />
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <Style x:Key="DefaultDatePickerStyle" TargetType="{x:Type DatePicker}">


### PR DESCRIPTION
### Description

DatePicker in WPF is inherently different as compared to WinUI's CalendarDatePicker although they have similar UI and perform the same functions. 
- WPF's DatePicker is composed of a TextBox and Button 
- Whereas the WinUI's CalendarDatePicker acts more like a button.

In this PR, I have tried to match the DatePicker control to some extent with the WinUI's CalendarDatePicker, while maintaining the original components of WPF's DatePicker. 


**However, given this difference there are a few questions that come to mind regarding the style of DatePicker :** 
1. Should DatePicker have an AccentBorder like the TextBox and other controls ?
2. Should ContentAlignment properties work as before in WPF ( in WinUI, these properties don't work for CalendarDatePicker )
3. How do I style the Calendar button in DatePicker ? ( currently it is styled similar to WinUI's TextBox clear button )